### PR TITLE
Fix infinite recursion in case of duplicate points

### DIFF
--- a/src/main/scala-2.11/de/mips/BallTree.scala
+++ b/src/main/scala-2.11/de/mips/BallTree.scala
@@ -9,6 +9,8 @@ import de.mips.data.{BestMatch, VectorWithExternalId}
 import de.mips.geometric.Ball
 
 final case class BallTree(points: IndexedSeq[VectorWithExternalId],leafSize:Int = 50) extends Serializable {
+  
+  val epsilon = 0.000001
 
   //using java version of Random() cause the scala version is only serializable since scala version 2.11
   val randomIntGenerator = new java.util.Random()
@@ -63,8 +65,9 @@ final case class BallTree(points: IndexedSeq[VectorWithExternalId],leafSize:Int 
 
   private def makeBallTree(pointIdx: Seq[Int]): Node = {
     val mu = mean(pointIdx)
-    val ball = Ball(mu, radius(pointIdx, mu))
-    if (pointIdx.length <= leafSize) {
+    val r = radius(pointIdx, mu)
+    val ball = Ball(mu, r)
+    if (pointIdx.length <= leafSize || r < epsilon) {
       //Leaf Node
       LeafNode(pointIdx, ball)
     } else {


### PR DESCRIPTION
If a node ends up with all identical points the split might end up
putting all nodes in the same child, causing an infinite recursion.
Reproducible with:

```
val p1 = VectorWithExternalId("Linus", DenseVector(1.0))
val p2 = VectorWithExternalId("Bill",  DenseVector(1.0))
new BallTree(IndexedSeq(p1, p2), leafSize = 1)
```
